### PR TITLE
workaround for missing rpath info

### DIFF
--- a/build
+++ b/build
@@ -127,7 +127,7 @@ SECONDS=0
 git clone https://github.com/MRtrix3/mrtrix3.git mrtrix3-src -b ${TAGNAME}
 cd ${PREFIX}-src
 MRTRIX_VERSION=$(git describe --abbrev=8 | tr '-' '_')
-CFLAGS="-I${PREFIX}/include" LINKFLAGS="-L${PREFIX}/lib" TIFF_LINKFLAGS="-ltiff" PATH=${PREFIX}/bin:${PATH} ./configure
+CFLAGS="-I${PREFIX}/include" LINKFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib" TIFF_LINKFLAGS="-ltiff" PATH=${PREFIX}/bin:${PATH} ./configure
 NUMBER_OF_PROCESSORS=${THREADS} ./build
 cd ..
 MRTRIX_SECONDS=${SECONDS}


### PR DESCRIPTION
This provides a workaround for https://github.com/MRtrix3/mrtrix3/pull/2543#issuecomment-1351554324.

For the next release it might be useful to revert parts of https://github.com/MRtrix3/mrtrix3/commit/6650a00115dc40bdf57c13c29d90a9bbca66cb9f ?