### PR TITLE
Fix Qt download url + optional argument to specify version

### DIFF
--- a/build
+++ b/build
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 TAGNAME="$1"
+QT_SPECIFIED="$2"
 
 PATH=/bin:/sbin:/usr/bin:/usr/sbin
 export PATH
@@ -30,9 +31,14 @@ else
   FFTW_VERSION=${FFTW_VERSION#*/*/fftw-}
   echo "Using fftw ${FFTW_VERSION}"
 
-  QT_VERSION=$(git ls-remote --tags https://code.qt.io/qt/qt5.git | awk '{print $2}' | grep -v '\^{}$' | grep -v alpha | grep -v beta | grep -v rc | grep -v '-' | grep '5.' | sort -V | tail -1)
-  QT_VERSION=${QT_VERSION#*/*/v}
-  echo "Using qt ${QT_VERSION}"
+  if [ -n "${QT_SPECIFIED}" ]; then
+    QT_VERSION="${QT_SPECIFIED}"
+    echo "Using user-specified qt ${QT_VERSION}"
+  else
+    QT_VERSION=$(git ls-remote --tags https://code.qt.io/qt/qt5.git | awk '{print $2}' | grep -v '\^{}$' | grep -v alpha | grep -v beta | grep -v rc | grep -v '-' | grep '5.' | sort -V | tail -1)
+    QT_VERSION=${QT_VERSION#*/*/v}
+    echo "Using auto-detected qt ${QT_VERSION}"
+  fi
 
   # EIGEN
   SECONDS=0

--- a/build
+++ b/build
@@ -93,7 +93,7 @@ else
   SECONDS=0
   DNAME=qtbase-everywhere-src-${QT_VERSION}
   FNAME=${DNAME}.tar.xz
-  curl -s -O http://ftp1.nluug.nl/languages/qt/archive/qt/${QT_VERSION%.*}/${QT_VERSION}/submodules/${FNAME}
+  curl -s -O http://ftp.nluug.nl/languages/qt/archive/qt/${QT_VERSION%.*}/${QT_VERSION}/submodules/${FNAME}
   tar xf ${FNAME}
   cd ${DNAME}
   curl -s -O https://raw.githubusercontent.com/wrobelda/vcpkg/99582d154236b0e7af70cadef8420c4f25829f61/ports/qt5-base/patches/cocoa.patch


### PR DESCRIPTION
Fixes Qt's binaries URL. Also modifies the `build` script to accept a second argument to specify the version of Qt to be used.